### PR TITLE
feat: add output control - custom directory & file organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ claims render [flags]
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--api-url` | `-a` | API URL (default: `$CLAIM_API_URL` or `http://localhost:8080`) |
+| `--output-dir` | `-o` | Output directory for rendered files (default: `/tmp`) |
+| `--dry-run` | | Print output without writing files |
+| `--single-file` | | Combine all resources into one file |
+| `--filename-pattern` | | Pattern for output filenames (default: `{{.template}}-{{.name}}.yaml`) |
 
 **Examples:**
 
@@ -56,6 +60,18 @@ claims render --api-url http://api.example.com:8080
 
 # Via environment variable
 CLAIM_API_URL=http://api.example.com:8080 claims render
+
+# Save to custom directory
+claims render -o ./manifests
+
+# Dry run (preview without writing)
+claims render --dry-run
+
+# Combine all resources into single file
+claims render -o ./out --single-file
+
+# Custom filename pattern
+claims render -o ./out --filename-pattern "{{.name}}.yaml"
 ```
 
 ## Configuration
@@ -85,16 +101,24 @@ task --list
 
 ```
 .
-├── main.go           # Application entry point
+├── main.go                    # Application entry point
 ├── cmd/
-│   ├── root.go       # Root command setup
-│   ├── render.go     # Render command implementation
-│   ├── version.go    # Version command
-│   └── logo.go       # ASCII logo rendering
-├── go.mod            # Go module definition
-├── Taskfile.yaml     # Task automation
-├── catalog-info.yaml # Backstage component definition
-└── README.md         # This file
+│   ├── root.go                # Root command setup
+│   ├── render.go              # Render command and flags
+│   ├── render_interactive.go  # Interactive form-based rendering
+│   ├── render_output.go       # File output logic (separate/single file, dry-run)
+│   ├── render_types.go        # Type definitions for render config/results
+│   ├── version.go             # Version command
+│   └── logo.go                # ASCII logo rendering
+├── internal/
+│   └── templates/
+│       ├── types.go           # API data models
+│       ├── client.go          # HTTP client for claim-machinery API
+│       └── client_test.go     # Client unit tests
+├── go.mod                     # Go module definition
+├── Taskfile.yaml              # Task automation
+├── catalog-info.yaml          # Backstage component definition
+└── README.md                  # This file
 ```
 
 ## License

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -8,7 +8,13 @@ import (
 	"github.com/stuttgart-things/claims/internal/templates"
 )
 
-var apiURL string
+var (
+	apiURL          string
+	outputDir       string
+	dryRun          bool
+	singleFile      bool
+	filenamePattern string
+)
 
 var renderCmd = &cobra.Command{
 	Use:   "render",
@@ -19,6 +25,10 @@ var renderCmd = &cobra.Command{
 
 func init() {
 	renderCmd.Flags().StringVarP(&apiURL, "api-url", "a", "", "API URL (default: $CLAIM_API_URL or http://localhost:8080)")
+	renderCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "/tmp", "Output directory for rendered files")
+	renderCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print output without writing files")
+	renderCmd.Flags().BoolVar(&singleFile, "single-file", false, "Combine all resources into one file")
+	renderCmd.Flags().StringVar(&filenamePattern, "filename-pattern", "{{.template}}-{{.name}}.yaml", "Pattern for output filenames")
 	rootCmd.AddCommand(renderCmd)
 }
 

--- a/cmd/render_output.go
+++ b/cmd/render_output.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// OutputConfig holds configuration for file output
+type OutputConfig struct {
+	Directory       string
+	FilenamePattern string
+	SingleFile      bool
+	DryRun          bool
+}
+
+// FileInfo holds information used for filename generation
+type FileInfo struct {
+	TemplateName string
+	ResourceName string
+}
+
+// GenerateFilename creates a filename from pattern and file info
+func GenerateFilename(pattern string, info FileInfo) (string, error) {
+	tmpl, err := template.New("filename").Parse(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid filename pattern: %w", err)
+	}
+
+	data := map[string]string{
+		"template": info.TemplateName,
+		"name":     info.ResourceName,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing filename template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// WriteResults writes render results to files based on the output configuration
+func WriteResults(results []RenderResult, config OutputConfig) error {
+	if config.DryRun {
+		return printDryRun(results, config)
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(config.Directory, 0755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	if config.SingleFile {
+		return writeSingleFile(results, config)
+	}
+	return writeSeparateFiles(results, config)
+}
+
+// writeSingleFile combines all results into a single YAML file separated by ---
+func writeSingleFile(results []RenderResult, config OutputConfig) error {
+	var combined strings.Builder
+
+	for i, r := range results {
+		if r.Error != nil {
+			continue // Skip failed renders
+		}
+		if combined.Len() > 0 {
+			combined.WriteString("\n---\n")
+		}
+		// Ensure content doesn't have leading/trailing newlines for cleaner output
+		combined.WriteString(strings.TrimSpace(r.Content))
+		if i < len(results)-1 {
+			combined.WriteString("\n")
+		}
+	}
+
+	// Use first template name for combined file
+	filename := "combined-claims.yaml"
+	if len(results) > 0 && results[0].TemplateName != "" {
+		filename = fmt.Sprintf("%s-combined.yaml", results[0].TemplateName)
+	}
+
+	path := filepath.Join(config.Directory, filename)
+	if err := os.WriteFile(path, []byte(combined.String()), 0644); err != nil {
+		return fmt.Errorf("writing combined file: %w", err)
+	}
+
+	fmt.Printf("Saved combined file: %s\n", path)
+	return nil
+}
+
+// writeSeparateFiles writes each result to its own file
+func writeSeparateFiles(results []RenderResult, config OutputConfig) error {
+	for i, r := range results {
+		if r.Error != nil {
+			continue // Skip failed renders
+		}
+
+		filename, err := GenerateFilename(config.FilenamePattern, FileInfo{
+			TemplateName: r.TemplateName,
+			ResourceName: r.ResourceName,
+		})
+		if err != nil {
+			return err
+		}
+
+		path := filepath.Join(config.Directory, filename)
+		if err := os.WriteFile(path, []byte(r.Content), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", path, err)
+		}
+
+		// Update the result with the output path
+		results[i].OutputPath = path
+		fmt.Printf("Saved: %s\n", path)
+	}
+	return nil
+}
+
+// printDryRun displays what would be written without actually writing files
+func printDryRun(results []RenderResult, config OutputConfig) error {
+	fmt.Println("\n=== DRY RUN - No files written ===")
+
+	if config.SingleFile {
+		filename := "combined-claims.yaml"
+		if len(results) > 0 && results[0].TemplateName != "" {
+			filename = fmt.Sprintf("%s-combined.yaml", results[0].TemplateName)
+		}
+		path := filepath.Join(config.Directory, filename)
+		fmt.Printf("Would write combined file: %s\n\n", path)
+
+		for i, r := range results {
+			if r.Error != nil {
+				fmt.Printf("# Skipping failed render: %s/%s\n", r.TemplateName, r.ResourceName)
+				continue
+			}
+			if i > 0 {
+				fmt.Println("---")
+			}
+			fmt.Println(yamlStyle.Render(strings.TrimSpace(r.Content)))
+		}
+	} else {
+		for _, r := range results {
+			if r.Error != nil {
+				fmt.Printf("# Skipping failed render: %s/%s - %v\n", r.TemplateName, r.ResourceName, r.Error)
+				continue
+			}
+
+			filename, err := GenerateFilename(config.FilenamePattern, FileInfo{
+				TemplateName: r.TemplateName,
+				ResourceName: r.ResourceName,
+			})
+			if err != nil {
+				filename = fmt.Sprintf("%s-%s.yaml", r.TemplateName, r.ResourceName)
+			}
+			path := filepath.Join(config.Directory, filename)
+
+			fmt.Printf("Would write: %s\n", path)
+			fmt.Println(yamlStyle.Render(strings.TrimSpace(r.Content)))
+			fmt.Println()
+		}
+	}
+	return nil
+}
+
+// WriteSingleResult writes a single render result using the output configuration
+// This is a convenience function for backward compatibility with single-template rendering
+func WriteSingleResult(templateName, resourceName, content string, config OutputConfig) error {
+	result := RenderResult{
+		TemplateName: templateName,
+		ResourceName: resourceName,
+		Content:      content,
+	}
+	return WriteResults([]RenderResult{result}, config)
+}

--- a/cmd/render_output_test.go
+++ b/cmd/render_output_test.go
@@ -1,0 +1,348 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		info     FileInfo
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:    "default pattern",
+			pattern: "{{.template}}-{{.name}}.yaml",
+			info: FileInfo{
+				TemplateName: "vsphere-vm",
+				ResourceName: "my-vm",
+			},
+			expected: "vsphere-vm-my-vm.yaml",
+		},
+		{
+			name:    "name only pattern",
+			pattern: "{{.name}}.yaml",
+			info: FileInfo{
+				TemplateName: "vsphere-vm",
+				ResourceName: "my-vm",
+			},
+			expected: "my-vm.yaml",
+		},
+		{
+			name:    "template only pattern",
+			pattern: "{{.template}}.yaml",
+			info: FileInfo{
+				TemplateName: "postgres-db",
+				ResourceName: "test-db",
+			},
+			expected: "postgres-db.yaml",
+		},
+		{
+			name:    "custom pattern with prefix",
+			pattern: "claim-{{.template}}-{{.name}}.yaml",
+			info: FileInfo{
+				TemplateName: "redis",
+				ResourceName: "cache",
+			},
+			expected: "claim-redis-cache.yaml",
+		},
+		{
+			name:    "invalid template syntax",
+			pattern: "{{.invalid",
+			info: FileInfo{
+				TemplateName: "test",
+				ResourceName: "test",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GenerateFilename(tt.pattern, tt.info)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestWriteResults_SeparateFiles(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "claims-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	results := []RenderResult{
+		{
+			TemplateName: "template1",
+			ResourceName: "resource1",
+			Content:      "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: resource1",
+		},
+		{
+			TemplateName: "template2",
+			ResourceName: "resource2",
+			Content:      "apiVersion: v1\nkind: Secret\nmetadata:\n  name: resource2",
+		},
+	}
+
+	config := OutputConfig{
+		Directory:       tmpDir,
+		FilenamePattern: "{{.template}}-{{.name}}.yaml",
+		SingleFile:      false,
+		DryRun:          false,
+	}
+
+	err = WriteResults(results, config)
+	if err != nil {
+		t.Fatalf("WriteResults failed: %v", err)
+	}
+
+	// Verify files were created
+	file1 := filepath.Join(tmpDir, "template1-resource1.yaml")
+	file2 := filepath.Join(tmpDir, "template2-resource2.yaml")
+
+	content1, err := os.ReadFile(file1)
+	if err != nil {
+		t.Errorf("failed to read %s: %v", file1, err)
+	}
+	if string(content1) != results[0].Content {
+		t.Errorf("file1 content mismatch")
+	}
+
+	content2, err := os.ReadFile(file2)
+	if err != nil {
+		t.Errorf("failed to read %s: %v", file2, err)
+	}
+	if string(content2) != results[1].Content {
+		t.Errorf("file2 content mismatch")
+	}
+}
+
+func TestWriteResults_SingleFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claims-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	results := []RenderResult{
+		{
+			TemplateName: "mytemplate",
+			ResourceName: "resource1",
+			Content:      "apiVersion: v1\nkind: ConfigMap",
+		},
+		{
+			TemplateName: "mytemplate",
+			ResourceName: "resource2",
+			Content:      "apiVersion: v1\nkind: Secret",
+		},
+	}
+
+	config := OutputConfig{
+		Directory:  tmpDir,
+		SingleFile: true,
+		DryRun:     false,
+	}
+
+	err = WriteResults(results, config)
+	if err != nil {
+		t.Fatalf("WriteResults failed: %v", err)
+	}
+
+	// Verify combined file was created
+	combinedFile := filepath.Join(tmpDir, "mytemplate-combined.yaml")
+	content, err := os.ReadFile(combinedFile)
+	if err != nil {
+		t.Fatalf("failed to read combined file: %v", err)
+	}
+
+	// Check that content is combined with ---
+	if !strings.Contains(string(content), "---") {
+		t.Errorf("combined file should contain --- separator")
+	}
+	if !strings.Contains(string(content), "ConfigMap") {
+		t.Errorf("combined file should contain first resource")
+	}
+	if !strings.Contains(string(content), "Secret") {
+		t.Errorf("combined file should contain second resource")
+	}
+}
+
+func TestWriteResults_DryRun(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claims-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	results := []RenderResult{
+		{
+			TemplateName: "test",
+			ResourceName: "test",
+			Content:      "test content",
+		},
+	}
+
+	config := OutputConfig{
+		Directory:       tmpDir,
+		FilenamePattern: "{{.template}}-{{.name}}.yaml",
+		SingleFile:      false,
+		DryRun:          true,
+	}
+
+	err = WriteResults(results, config)
+	if err != nil {
+		t.Fatalf("WriteResults failed: %v", err)
+	}
+
+	// Verify no files were created
+	files, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to read dir: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("dry run should not create files, found %d", len(files))
+	}
+}
+
+func TestWriteResults_CreatesDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claims-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Use a nested directory that doesn't exist
+	nestedDir := filepath.Join(tmpDir, "nested", "output", "dir")
+
+	results := []RenderResult{
+		{
+			TemplateName: "test",
+			ResourceName: "test",
+			Content:      "test content",
+		},
+	}
+
+	config := OutputConfig{
+		Directory:       nestedDir,
+		FilenamePattern: "{{.template}}-{{.name}}.yaml",
+		SingleFile:      false,
+		DryRun:          false,
+	}
+
+	err = WriteResults(results, config)
+	if err != nil {
+		t.Fatalf("WriteResults failed: %v", err)
+	}
+
+	// Verify directory was created
+	if _, err := os.Stat(nestedDir); os.IsNotExist(err) {
+		t.Errorf("directory should have been created")
+	}
+
+	// Verify file exists
+	file := filepath.Join(nestedDir, "test-test.yaml")
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		t.Errorf("file should have been created")
+	}
+}
+
+func TestWriteResults_SkipsFailedResults(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claims-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	results := []RenderResult{
+		{
+			TemplateName: "success",
+			ResourceName: "resource",
+			Content:      "success content",
+		},
+		{
+			TemplateName: "failed",
+			ResourceName: "resource",
+			Content:      "should not be written",
+			Error:        &testError{},
+		},
+	}
+
+	config := OutputConfig{
+		Directory:       tmpDir,
+		FilenamePattern: "{{.template}}-{{.name}}.yaml",
+		SingleFile:      false,
+		DryRun:          false,
+	}
+
+	err = WriteResults(results, config)
+	if err != nil {
+		t.Fatalf("WriteResults failed: %v", err)
+	}
+
+	// Verify only success file was created
+	successFile := filepath.Join(tmpDir, "success-resource.yaml")
+	failedFile := filepath.Join(tmpDir, "failed-resource.yaml")
+
+	if _, err := os.Stat(successFile); os.IsNotExist(err) {
+		t.Errorf("success file should exist")
+	}
+	if _, err := os.Stat(failedFile); !os.IsNotExist(err) {
+		t.Errorf("failed file should not exist")
+	}
+}
+
+func TestWriteSingleResult(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claims-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	config := OutputConfig{
+		Directory:       tmpDir,
+		FilenamePattern: "{{.template}}-{{.name}}.yaml",
+		SingleFile:      false,
+		DryRun:          false,
+	}
+
+	err = WriteSingleResult("mytemplate", "myresource", "test: content", config)
+	if err != nil {
+		t.Fatalf("WriteSingleResult failed: %v", err)
+	}
+
+	file := filepath.Join(tmpDir, "mytemplate-myresource.yaml")
+	content, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(content) != "test: content" {
+		t.Errorf("content mismatch: got %q", string(content))
+	}
+}
+
+// testError is a simple error type for testing
+type testError struct{}
+
+func (e *testError) Error() string { return "test error" }


### PR DESCRIPTION
## Summary
- Add flexible output options: custom directory, single/multiple files, filename patterns
- Add `--output-dir`, `--dry-run`, `--single-file`, `--filename-pattern` flags
- Implement single-file vs separate-files output modes
- Add interactive output configuration form
- Create `cmd/render_output.go` with file writing logic
- Add comprehensive unit tests for output functionality
- Update README with new flags and examples

## New Flags
| Flag | Short | Description |
|------|-------|-------------|
| `--output-dir` | `-o` | Output directory for rendered files (default: `/tmp`) |
| `--dry-run` | | Print output without writing files |
| `--single-file` | | Combine all resources into one file |
| `--filename-pattern` | | Pattern for output filenames (default: `{{.template}}-{{.name}}.yaml`) |

## Test plan
- [x] Unit tests for `GenerateFilename()` function
- [x] Unit tests for separate files output mode
- [x] Unit tests for single file output mode  
- [x] Unit tests for dry-run mode
- [x] Unit tests for directory creation
- [x] Unit tests for skipping failed results
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)