### PR TITLE
feat: add multi-template support for batch rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ claims render [flags]
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--api-url` | `-a` | API URL (default: `$CLAIM_API_URL` or `http://localhost:8080`) |
+| `--templates` | `-t` | Templates to render (comma-separated or repeated) |
 | `--output-dir` | `-o` | Output directory for rendered files (default: `/tmp`) |
 | `--dry-run` | | Print output without writing files |
 | `--single-file` | | Combine all resources into one file |
@@ -72,6 +73,12 @@ claims render -o ./out --single-file
 
 # Custom filename pattern
 claims render -o ./out --filename-pattern "{{.name}}.yaml"
+
+# Render multiple templates (interactive params for each)
+claims render -t vsphere-vm -t postgres-db
+
+# Render multiple templates (comma-separated)
+claims render -t vsphere-vm,postgres-db -o ./out
 ```
 
 ## Configuration

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -9,11 +9,12 @@ import (
 )
 
 var (
-	apiURL          string
-	outputDir       string
-	dryRun          bool
-	singleFile      bool
-	filenamePattern string
+	apiURL           string
+	outputDir        string
+	dryRun           bool
+	singleFile       bool
+	filenamePattern  string
+	templateNames    []string
 )
 
 var renderCmd = &cobra.Command{
@@ -29,6 +30,7 @@ func init() {
 	renderCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print output without writing files")
 	renderCmd.Flags().BoolVar(&singleFile, "single-file", false, "Combine all resources into one file")
 	renderCmd.Flags().StringVar(&filenamePattern, "filename-pattern", "{{.template}}-{{.name}}.yaml", "Pattern for output filenames")
+	renderCmd.Flags().StringSliceVarP(&templateNames, "templates", "t", nil, "Templates to render (comma-separated or repeated)")
 	rootCmd.AddCommand(renderCmd)
 }
 


### PR DESCRIPTION
## Summary
- Enable selecting and rendering multiple templates in a single operation
- Add `--templates` / `-t` flag for non-interactive multi-template selection
- Implement `huh.MultiSelect` for interactive template selection
- Add per-template parameter collection loop with progress indicators
- Batch rendering with aggregated results display

## New Flag
| Flag | Short | Description |
|------|-------|-------------|
| `--templates` | `-t` | Templates to render (comma-separated or repeated) |

## Interactive Flow
```
Select templates to render (space to select, enter to confirm):
> [x] vsphere-vm - VMware vSphere Virtual Machine
  [x] postgres-db - PostgreSQL Database
  [ ] ansible-execution-env - Ansible Execution Environment
```

## New Functions
- `selectTemplates()` - Multi-select form for template selection
- `collectAllParams()` - Loop through selected templates for parameter collection
- `collectTemplateParams()` - Collect parameters for a single template (refactored)
- `renderAllTemplates()` - Batch render all templates
- `displayResults()` - Show aggregated render results

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 14 tests)
- [x] `go vet ./...` passes
- [x] New `--templates` flag appears in help output
- [x] Template validation for non-existent templates

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)