### PR TITLE
fix: push only the current branch instead of all local branches

### DIFF
--- a/cmd/render_git.go
+++ b/cmd/render_git.go
@@ -111,8 +111,18 @@ func executeGitOperations(results []RenderResult, config *RenderConfig) error {
 		if remote == "" {
 			remote = "origin"
 		}
+
+		// Get branch name to push
+		branch := config.GitConfig.Branch
+		if branch == "" {
+			branch, err = g.GetCurrentBranch()
+			if err != nil {
+				return fmt.Errorf("getting current branch: %w", err)
+			}
+		}
+
 		fmt.Printf("Pushing to %s...\n", remote)
-		if err := g.Push(remote); err != nil {
+		if err := g.Push(remote, branch); err != nil {
 			return err
 		}
 		fmt.Println(successStyle.Render("Pushed successfully"))

--- a/internal/gitops/operations.go
+++ b/internal/gitops/operations.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
@@ -145,14 +146,18 @@ func (g *GitOps) Commit(message, authorName, authorEmail string) error {
 	return nil
 }
 
-// Push pushes to remote
-func (g *GitOps) Push(remote string) error {
+// Push pushes a specific branch to remote
+func (g *GitOps) Push(remote, branch string) error {
 	if g.auth == nil {
 		return fmt.Errorf("git credentials required for push")
 	}
 
+	// Only push the specified branch, not all branches
+	refSpec := config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads/%s", branch, branch))
+
 	err := g.repo.Push(&git.PushOptions{
 		RemoteName: remote,
+		RefSpecs:   []config.RefSpec{refSpec},
 		Auth:       g.auth,
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {

--- a/internal/gitops/operations_test.go
+++ b/internal/gitops/operations_test.go
@@ -179,6 +179,7 @@ func TestPush(t *testing.T) {
 		user    string
 		token   string
 		remote  string
+		branch  string
 		wantErr bool
 	}{
 		{
@@ -186,6 +187,7 @@ func TestPush(t *testing.T) {
 			user:    "",
 			token:   "",
 			remote:  "origin",
+			branch:  "main",
 			wantErr: true,
 		},
 		{
@@ -193,6 +195,7 @@ func TestPush(t *testing.T) {
 			user:    "testuser",
 			token:   "testtoken",
 			remote:  "nonexistent",
+			branch:  "main",
 			wantErr: true,
 		},
 	}
@@ -204,7 +207,7 @@ func TestPush(t *testing.T) {
 				t.Fatalf("failed to create GitOps: %v", err)
 			}
 
-			err = g.Push(tt.remote)
+			err = g.Push(tt.remote, tt.branch)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Push() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
## Summary
- Fixed bug where `git push` was pushing ALL local branches instead of just the current branch
- The `Push` function now accepts a branch parameter and uses `RefSpecs` to push only that specific branch
- This prevents old/stale local branches from being recreated on the remote

## Changes
- `internal/gitops/operations.go`: Added `config` import, updated `Push` to accept branch name and use `RefSpecs`
- `cmd/render_git.go`: Updated to pass the branch name to `Push`
- `internal/gitops/operations_test.go`: Updated tests to include branch parameter

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Verified fix by running `claim render` - only the intended branch was pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)