### PR TITLE
feat: add multiselect parameter support

### DIFF
--- a/internal/templates/types.go
+++ b/internal/templates/types.go
@@ -36,6 +36,7 @@ type Parameter struct {
 	Pattern     string      `json:"pattern,omitempty"`
 	Hidden      bool        `json:"hidden,omitempty"`
 	AllowRandom bool        `json:"allowRandom,omitempty"`
+	Multiselect bool        `json:"multiselect,omitempty"`
 }
 
 // ClaimTemplateList is a list of claim templates


### PR DESCRIPTION
## Summary

- Add `Multiselect` field to `Parameter` struct so the CLI deserializes `multiselect: true` from the API
- Render `huh.NewMultiSelect` checkboxes for parameters with `multiselect: true` and `enum` values
- Handle array defaults and store selected values as `[]interface{}` for JSON array compatibility

Closes #42

## Test plan

- [ ] Verify `go build` and `go test` pass
- [ ] Test interactive rendering with a template containing `multiselect: true` + `enum` parameters
- [ ] Confirm multi-selected values are sent as JSON arrays to the API
- [ ] Confirm array defaults are pre-selected in the checkbox form
- [ ] Verify non-multiselect parameters still work as before (single select, random, hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)