### PR TITLE
Add volumeclaim claim - test-claim2

### DIFF
--- a/claims/claims/volumeclaim.yaml
+++ b/claims/claims/volumeclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: VolumeClaim
+metadata:
+  name: simple-storage
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  annotations:
+    description: A simple persistent volume claim for application data
+  namespace: default
+  providerConfigRef: harvester
+  pvcName: app-data
+  storage: '10Gi'
+  storageClassName: harvester-longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Claim Manifest Created via Backstage

**Template**: volumeclaim
**Claim Name**: test-claim2

### Manifest Details
```yaml
apiVersion: resources.stuttgart-things.com/v1alpha1
kind: VolumeClaim
metadata:
  name: simple-storage
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  annotations:
    description: A simple persistent volume claim for application data
  namespace: default
  providerConfigRef: harvester
  pvcName: app-data
  storage: '10Gi'
  storageClassName: harvester-longhorn
  volumeMode: Filesystem

```

Created automatically via Backstage Claim Machinery integration.
