### PR TITLE
feat: add delete and list commands with registry and kustomize support

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteResourceName string
+	deleteCategory     string
+	deleteRepoURL      string
+	deleteRegistryPath string
+	deleteDryRun       bool
+
+	// Git flags for delete (reuse same env vars)
+	deleteGitBranch       string
+	deleteGitCreateBranch bool
+	deleteGitMessage      string
+	deleteGitRemote       string
+	deleteGitUser         string
+	deleteGitToken        string
+
+	// PR flags for delete
+	deleteCreatePR      bool
+	deletePRTitle       string
+	deletePRDescription string
+	deletePRLabels      []string
+	deletePRBase        string
+
+	// Mode flags for delete
+	deleteInteractive    bool
+	deleteNonInteractive bool
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a claim via Git PR",
+	Long:  `Removes a Crossplane claim by deleting its directory, updating kustomization.yaml, and removing the registry entry. Creates a Git PR for the change.`,
+	Run:   runDelete,
+}
+
+func init() {
+	deleteCmd.Flags().StringVar(&deleteResourceName, "resource-name", "", "Name of the claim resource to delete")
+	deleteCmd.Flags().StringVar(&deleteCategory, "category", "", "Category of the claim (e.g., infra, apps)")
+	deleteCmd.Flags().StringVar(&deleteRepoURL, "git-repo-url", "", "Clone from URL instead of using local repo")
+	deleteCmd.Flags().StringVar(&deleteRegistryPath, "registry-path", "claims/registry.yaml", "Path to registry.yaml within the repo")
+	deleteCmd.Flags().BoolVar(&deleteDryRun, "dry-run", false, "Show what would be deleted without making changes")
+
+	// Git flags
+	deleteCmd.Flags().StringVar(&deleteGitBranch, "git-branch", "", "Branch to use/create")
+	deleteCmd.Flags().BoolVar(&deleteGitCreateBranch, "git-create-branch", false, "Create the branch if it doesn't exist")
+	deleteCmd.Flags().StringVar(&deleteGitMessage, "git-message", "", "Commit message (default: auto-generated)")
+	deleteCmd.Flags().StringVar(&deleteGitRemote, "git-remote", "origin", "Git remote name")
+	deleteCmd.Flags().StringVar(&deleteGitUser, "git-user", "", "Git username (or GIT_USER/GITHUB_USER env)")
+	deleteCmd.Flags().StringVar(&deleteGitToken, "git-token", "", "Git token (or GIT_TOKEN/GITHUB_TOKEN env)")
+
+	// PR flags
+	deleteCmd.Flags().BoolVar(&deleteCreatePR, "create-pr", false, "Create a pull request after push")
+	deleteCmd.Flags().StringVar(&deletePRTitle, "pr-title", "", "PR title (default: auto-generated)")
+	deleteCmd.Flags().StringVar(&deletePRDescription, "pr-description", "", "PR description")
+	deleteCmd.Flags().StringSliceVar(&deletePRLabels, "pr-labels", nil, "PR labels (comma-separated)")
+	deleteCmd.Flags().StringVar(&deletePRBase, "pr-base", "main", "Base branch for PR")
+
+	// Mode flags
+	deleteCmd.Flags().BoolVarP(&deleteInteractive, "interactive", "i", false, "Force interactive mode")
+	deleteCmd.Flags().BoolVar(&deleteNonInteractive, "non-interactive", false, "Force non-interactive mode")
+
+	rootCmd.AddCommand(deleteCmd)
+}
+
+func runDelete(cmd *cobra.Command, args []string) {
+	fmt.Println(logo)
+
+	config := &DeleteConfig{
+		ResourceName: deleteResourceName,
+		Category:     deleteCategory,
+		RepoURL:      deleteRepoURL,
+		RegistryPath: deleteRegistryPath,
+		DryRun:       deleteDryRun,
+	}
+
+	// Build git config
+	if deleteGitBranch != "" || deleteRepoURL != "" || deleteCreatePR {
+		config.GitConfig = &GitConfig{
+			Commit:       true,
+			Push:         true,
+			CreateBranch: deleteGitCreateBranch,
+			Message:      deleteGitMessage,
+			Branch:       deleteGitBranch,
+			Remote:       deleteGitRemote,
+			RepoURL:      deleteRepoURL,
+			User:         deleteGitUser,
+			Token:        deleteGitToken,
+		}
+	}
+
+	// Build PR config
+	if deleteCreatePR || deletePRTitle != "" || deletePRDescription != "" || len(deletePRLabels) > 0 {
+		config.PRConfig = &PRConfig{
+			Create:      deleteCreatePR,
+			Title:       deletePRTitle,
+			Description: deletePRDescription,
+			Labels:      deletePRLabels,
+			BaseBranch:  deletePRBase,
+		}
+	}
+
+	// Determine mode
+	if deleteNonInteractive {
+		config.Interactive = false
+	} else if deleteInteractive {
+		config.Interactive = true
+	} else {
+		config.Interactive = isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
+	}
+
+	var err error
+	if config.Interactive {
+		err = runDeleteInteractive(config)
+	} else {
+		err = runDeleteNonInteractive(config)
+	}
+
+	if err != nil {
+		fmt.Println(errorStyle.Render(err.Error()))
+		os.Exit(1)
+	}
+}

--- a/cmd/delete_interactive.go
+++ b/cmd/delete_interactive.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/charmbracelet/huh"
+	"github.com/stuttgart-things/claims/internal/registry"
+)
+
+// runDeleteInteractive runs the delete command in interactive mode
+func runDeleteInteractive(config *DeleteConfig) error {
+	// Determine repo root
+	repoRoot, err := resolveRepoRoot(config)
+	if err != nil {
+		return err
+	}
+
+	registryPath := filepath.Join(repoRoot, config.RegistryPath)
+
+	// Load registry
+	reg, err := registry.Load(registryPath)
+	if err != nil {
+		return fmt.Errorf("loading registry: %w", err)
+	}
+
+	if len(reg.Claims) == 0 {
+		fmt.Println("No claims found in registry.")
+		return nil
+	}
+
+	// Build select options from registry
+	var options []huh.Option[string]
+	for _, entry := range reg.Claims {
+		label := fmt.Sprintf("%s (%s/%s) [%s]", entry.Name, entry.Category, entry.Template, entry.Status)
+		options = append(options, huh.NewOption(label, entry.Name))
+	}
+
+	var selected string
+	selectForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Select claim to delete").
+				Description("Choose the claim to remove").
+				Options(options...).
+				Value(&selected),
+		),
+	)
+
+	if err := selectForm.Run(); err != nil {
+		return fmt.Errorf("selection form: %w", err)
+	}
+
+	entry := registry.FindEntry(reg, selected)
+	if entry == nil {
+		return fmt.Errorf("claim %q not found in registry", selected)
+	}
+
+	// Show what will be deleted
+	fmt.Printf("\nClaim to delete:\n")
+	fmt.Printf("  Name:       %s\n", entry.Name)
+	fmt.Printf("  Template:   %s\n", entry.Template)
+	fmt.Printf("  Category:   %s\n", entry.Category)
+	fmt.Printf("  Namespace:  %s\n", entry.Namespace)
+	fmt.Printf("  Path:       %s\n", entry.Path)
+	fmt.Printf("  Created by: %s\n", entry.CreatedBy)
+	fmt.Println()
+
+	// Confirm
+	var confirm bool
+	confirmForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("Delete claim %q?", selected)).
+				Description("This will remove the claim directory, update kustomization.yaml, and update registry.yaml").
+				Affirmative("Yes, delete").
+				Negative("Cancel").
+				Value(&confirm),
+		),
+	)
+
+	if err := confirmForm.Run(); err != nil {
+		return fmt.Errorf("confirmation form: %w", err)
+	}
+
+	if !confirm {
+		fmt.Println("Cancelled.")
+		return nil
+	}
+
+	if config.DryRun {
+		return printDeleteDryRun(entry.Name, entry.Category, entry.Path, repoRoot)
+	}
+
+	// Perform the deletion
+	result, err := performDelete(repoRoot, config.RegistryPath, entry.Name, entry.Category)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(successStyle.Render(fmt.Sprintf("\nDeleted claim: %s", result.ResourceName)))
+
+	// Ask about git operations if not already configured
+	if config.GitConfig == nil {
+		destChoice, err := runDeleteDestinationChoice()
+		if err != nil {
+			return fmt.Errorf("destination choice: %w", err)
+		}
+
+		if destChoice.useGit {
+			gitConfig, err := runGitDetailsForm(destChoice.createPR)
+			if err != nil {
+				return fmt.Errorf("git options: %w", err)
+			}
+			config.GitConfig = gitConfig
+
+			if destChoice.createPR {
+				prConfig, err := runPROptionsForm()
+				if err != nil {
+					return fmt.Errorf("PR options: %w", err)
+				}
+				config.PRConfig = prConfig
+			}
+		}
+	}
+
+	// Execute git operations
+	if config.GitConfig != nil {
+		if err := executeDeleteGitOperations(result, config, repoRoot); err != nil {
+			return fmt.Errorf("git operations: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// runDeleteDestinationChoice asks whether to commit+push+PR
+func runDeleteDestinationChoice() (destinationChoice, error) {
+	var destination string
+
+	// Check if we're in a git repo
+	cwd, err := os.Getwd()
+	if err != nil {
+		return destinationChoice{}, nil
+	}
+	if _, err := findRepoRoot(cwd); err != nil {
+		return destinationChoice{}, nil
+	}
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Create a Git PR for this deletion?").
+				Description("Choose how to handle the changes").
+				Options(
+					huh.NewOption("Create PR (commit, push & create PR)", "pr"),
+					huh.NewOption("Keep local changes only", "local"),
+				).
+				Value(&destination),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		return destinationChoice{}, err
+	}
+
+	return destinationChoice{
+		useGit:   destination == "pr",
+		createPR: destination == "pr",
+	}, nil
+}

--- a/cmd/delete_noninteractive.go
+++ b/cmd/delete_noninteractive.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/stuttgart-things/claims/internal/kustomize"
+	"github.com/stuttgart-things/claims/internal/registry"
+)
+
+// runDeleteNonInteractive runs the delete command in non-interactive mode
+func runDeleteNonInteractive(config *DeleteConfig) error {
+	if config.ResourceName == "" {
+		return fmt.Errorf("--resource-name is required in non-interactive mode")
+	}
+
+	// Determine repo root
+	repoRoot, err := resolveRepoRoot(config)
+	if err != nil {
+		return err
+	}
+
+	registryPath := filepath.Join(repoRoot, config.RegistryPath)
+
+	// Load registry
+	reg, err := registry.Load(registryPath)
+	if err != nil {
+		return fmt.Errorf("loading registry: %w", err)
+	}
+
+	// Find the claim
+	entry := registry.FindEntry(reg, config.ResourceName)
+	if entry == nil {
+		return fmt.Errorf("claim %q not found in registry", config.ResourceName)
+	}
+
+	// Use category from registry if not provided
+	category := config.Category
+	if category == "" {
+		category = entry.Category
+	}
+
+	if config.DryRun {
+		return printDeleteDryRun(config.ResourceName, category, entry.Path, repoRoot)
+	}
+
+	result, err := performDelete(repoRoot, config.RegistryPath, config.ResourceName, category)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(successStyle.Render(fmt.Sprintf("Deleted claim: %s", result.ResourceName)))
+
+	// Execute git operations
+	if config.GitConfig != nil {
+		if err := executeDeleteGitOperations(result, config, repoRoot); err != nil {
+			return fmt.Errorf("git operations: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// resolveRepoRoot determines the repository root path
+func resolveRepoRoot(config *DeleteConfig) (string, error) {
+	if config.RepoURL != "" {
+		// Clone-based workflow is handled in git operations
+		return "", fmt.Errorf("clone-based workflow requires git configuration; use --git-repo-url with git flags")
+	}
+
+	// Use current directory as starting point
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting working directory: %w", err)
+	}
+
+	repoRoot, err := findRepoRoot(cwd)
+	if err != nil {
+		return "", fmt.Errorf("not in a git repository: %w", err)
+	}
+
+	return repoRoot, nil
+}
+
+// performDelete removes the claim directory, updates kustomization.yaml, and updates registry.yaml
+func performDelete(repoRoot, registryRelPath, resourceName, category string) (*DeleteResult, error) {
+	claimDir := filepath.Join(repoRoot, "claims", category, resourceName)
+	kustomizationPath := filepath.Join(repoRoot, "claims", category, "kustomization.yaml")
+	registryPath := filepath.Join(repoRoot, registryRelPath)
+
+	// Verify claim directory exists
+	if _, err := os.Stat(claimDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("claim directory not found: %s", claimDir)
+	}
+
+	// Remove claim directory
+	if err := os.RemoveAll(claimDir); err != nil {
+		return nil, fmt.Errorf("removing claim directory: %w", err)
+	}
+	fmt.Printf("Removed directory: %s\n", claimDir)
+
+	// Update kustomization.yaml
+	if _, err := os.Stat(kustomizationPath); err == nil {
+		k, err := kustomize.Load(kustomizationPath)
+		if err != nil {
+			return nil, fmt.Errorf("loading kustomization: %w", err)
+		}
+
+		if err := kustomize.RemoveResource(k, resourceName); err != nil {
+			fmt.Printf("Warning: %v\n", err)
+		} else {
+			if err := kustomize.Save(kustomizationPath, k); err != nil {
+				return nil, fmt.Errorf("saving kustomization: %w", err)
+			}
+			fmt.Printf("Updated kustomization: %s\n", kustomizationPath)
+		}
+	}
+
+	// Update registry.yaml
+	reg, err := registry.Load(registryPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading registry: %w", err)
+	}
+
+	if err := registry.RemoveEntry(reg, resourceName); err != nil {
+		fmt.Printf("Warning: %v\n", err)
+	} else {
+		if err := registry.Save(registryPath, reg); err != nil {
+			return nil, fmt.Errorf("saving registry: %w", err)
+		}
+		fmt.Printf("Updated registry: %s\n", registryPath)
+	}
+
+	return &DeleteResult{
+		ResourceName: resourceName,
+		Category:     category,
+		Path:         filepath.Join("claims", category, resourceName),
+	}, nil
+}
+
+// printDeleteDryRun shows what would be deleted
+func printDeleteDryRun(resourceName, category, path, repoRoot string) error {
+	fmt.Println("\n=== DRY RUN - No changes made ===")
+	fmt.Printf("Would delete claim: %s\n", resourceName)
+	fmt.Printf("  Category:    %s\n", category)
+	fmt.Printf("  Directory:   %s\n", filepath.Join(repoRoot, "claims", category, resourceName))
+	fmt.Printf("  Registry:    remove entry from registry.yaml\n")
+	fmt.Printf("  Kustomize:   remove resource from claims/%s/kustomization.yaml\n", category)
+	return nil
+}

--- a/cmd/delete_types.go
+++ b/cmd/delete_types.go
@@ -1,0 +1,23 @@
+package cmd
+
+// DeleteConfig holds configuration for the delete command
+type DeleteConfig struct {
+	ResourceName string
+	Category     string
+	RepoURL      string
+	RegistryPath string
+
+	Interactive bool
+	DryRun      bool
+
+	GitConfig *GitConfig
+	PRConfig  *PRConfig
+}
+
+// DeleteResult holds the result of deleting a single claim
+type DeleteResult struct {
+	ResourceName string
+	Category     string
+	Path         string
+	Error        error
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/stuttgart-things/claims/internal/registry"
+)
+
+var (
+	listRegistryPath string
+	listCategory     string
+	listTemplate     string
+	listOutput       string
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List claims from registry",
+	Long:  `Lists all claims registered in claims/registry.yaml, with optional filtering by category or template.`,
+	Run:   runList,
+}
+
+func init() {
+	listCmd.Flags().StringVar(&listRegistryPath, "registry-path", "claims/registry.yaml", "Path to registry.yaml")
+	listCmd.Flags().StringVar(&listCategory, "category", "", "Filter by category")
+	listCmd.Flags().StringVar(&listTemplate, "template", "", "Filter by template")
+	listCmd.Flags().StringVarP(&listOutput, "output", "o", "table", "Output format (table, json)")
+
+	rootCmd.AddCommand(listCmd)
+}
+
+func runList(cmd *cobra.Command, args []string) {
+	// Resolve registry path
+	registryPath := listRegistryPath
+
+	// If not absolute, try relative to repo root
+	if !filepath.IsAbs(registryPath) {
+		cwd, err := os.Getwd()
+		if err == nil {
+			repoRoot, err := findRepoRoot(cwd)
+			if err == nil {
+				registryPath = filepath.Join(repoRoot, registryPath)
+			}
+		}
+	}
+
+	reg, err := registry.Load(registryPath)
+	if err != nil {
+		fmt.Println(errorStyle.Render(fmt.Sprintf("Error loading registry: %v", err)))
+		os.Exit(1)
+	}
+
+	entries := registry.FilterEntries(reg, listCategory, listTemplate)
+
+	if len(entries) == 0 {
+		fmt.Println("No claims found.")
+		return
+	}
+
+	switch listOutput {
+	case "json":
+		printJSON(entries)
+	default:
+		printTable(entries)
+	}
+}
+
+func printTable(entries []registry.ClaimEntry) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tTEMPLATE\tCATEGORY\tNAMESPACE\tSTATUS\tCREATED BY\tSOURCE")
+	fmt.Fprintln(w, "----\t--------\t--------\t---------\t------\t----------\t------")
+
+	for _, e := range entries {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			e.Name, e.Template, e.Category, e.Namespace, e.Status, e.CreatedBy, e.Source)
+	}
+
+	w.Flush()
+}
+
+func printJSON(entries []registry.ClaimEntry) {
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		fmt.Println(errorStyle.Render(fmt.Sprintf("Error marshalling JSON: %v", err)))
+		os.Exit(1)
+	}
+	fmt.Println(string(data))
+}

--- a/cmd/render_interactive.go
+++ b/cmd/render_interactive.go
@@ -253,11 +253,14 @@ func runInteractiveRender(client *templates.Client, config *RenderConfig) error 
 		return fmt.Errorf("writing output: %w", err)
 	}
 
+	// Update registry if output was written (and not dry-run)
+	if !outputConfig.DryRun {
+		config.OutputDir = outputConfig.Directory
+		updateRegistryForRender(results, config)
+	}
+
 	// Execute git operations if configured (and not dry-run)
 	if !outputConfig.DryRun && config.GitConfig != nil {
-		// Update config with the actual output directory used
-		config.OutputDir = outputConfig.Directory
-
 		if err := executeGitOperations(results, config); err != nil {
 			return fmt.Errorf("git operations: %w", err)
 		}

--- a/cmd/render_noninteractive.go
+++ b/cmd/render_noninteractive.go
@@ -123,6 +123,11 @@ func runNonInteractive(config *RenderConfig) error {
 		return err
 	}
 
+	// Update registry if output was written (and not dry-run)
+	if !config.DryRun {
+		updateRegistryForRender(results, config)
+	}
+
 	// Execute git operations if configured (and not dry-run)
 	if !config.DryRun {
 		if err := executeGitOperations(results, config); err != nil {

--- a/internal/kustomize/kustomize.go
+++ b/internal/kustomize/kustomize.go
@@ -1,0 +1,66 @@
+package kustomize
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Kustomization represents a kustomization.yaml file
+type Kustomization struct {
+	APIVersion string   `yaml:"apiVersion,omitempty"`
+	Kind       string   `yaml:"kind,omitempty"`
+	Resources  []string `yaml:"resources"`
+}
+
+// Load reads and parses a kustomization.yaml file
+func Load(path string) (*Kustomization, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading kustomization file: %w", err)
+	}
+
+	var k Kustomization
+	if err := yaml.Unmarshal(data, &k); err != nil {
+		return nil, fmt.Errorf("parsing kustomization file: %w", err)
+	}
+
+	return &k, nil
+}
+
+// Save writes a Kustomization to a YAML file
+func Save(path string, k *Kustomization) error {
+	data, err := yaml.Marshal(k)
+	if err != nil {
+		return fmt.Errorf("marshalling kustomization: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing kustomization file: %w", err)
+	}
+
+	return nil
+}
+
+// AddResource adds a resource entry if it doesn't already exist
+func AddResource(k *Kustomization, resource string) {
+	for _, r := range k.Resources {
+		if r == resource {
+			return
+		}
+	}
+	k.Resources = append(k.Resources, resource)
+}
+
+// RemoveResource removes a resource entry by value.
+// Returns an error if the resource is not found.
+func RemoveResource(k *Kustomization, resource string) error {
+	for i, r := range k.Resources {
+		if r == resource {
+			k.Resources = append(k.Resources[:i], k.Resources[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("resource %q not found in kustomization", resource)
+}

--- a/internal/kustomize/kustomize_test.go
+++ b/internal/kustomize/kustomize_test.go
@@ -1,0 +1,76 @@
+package kustomize
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAndSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kustomization.yaml")
+
+	k := &Kustomization{
+		APIVersion: "kustomize.config.k8s.io/v1beta1",
+		Kind:       "Kustomization",
+		Resources:  []string{"app-pvc", "db-pvc"},
+	}
+
+	if err := Save(path, k); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(loaded.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(loaded.Resources))
+	}
+	if loaded.Resources[0] != "app-pvc" {
+		t.Errorf("expected app-pvc, got %s", loaded.Resources[0])
+	}
+}
+
+func TestAddResource(t *testing.T) {
+	k := &Kustomization{Resources: []string{"a"}}
+
+	AddResource(k, "b")
+	if len(k.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(k.Resources))
+	}
+
+	// Adding duplicate should be a no-op
+	AddResource(k, "b")
+	if len(k.Resources) != 2 {
+		t.Fatalf("expected 2 resources after duplicate add, got %d", len(k.Resources))
+	}
+}
+
+func TestRemoveResource(t *testing.T) {
+	k := &Kustomization{Resources: []string{"a", "b", "c"}}
+
+	if err := RemoveResource(k, "b"); err != nil {
+		t.Fatalf("RemoveResource: %v", err)
+	}
+	if len(k.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(k.Resources))
+	}
+	if k.Resources[0] != "a" || k.Resources[1] != "c" {
+		t.Errorf("unexpected resources: %v", k.Resources)
+	}
+}
+
+func TestRemoveResourceNotFound(t *testing.T) {
+	k := &Kustomization{Resources: []string{"a"}}
+	if err := RemoveResource(k, "missing"); err == nil {
+		t.Fatal("expected error for missing resource")
+	}
+}
+
+func TestLoadNotFound(t *testing.T) {
+	_, err := Load("/nonexistent/kustomization.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,108 @@
+package registry
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultAPIVersion = "claim-registry.io/v1alpha1"
+	DefaultKind       = "ClaimRegistry"
+)
+
+// Load reads and parses a registry.yaml file
+func Load(path string) (*ClaimRegistry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading registry file: %w", err)
+	}
+
+	var reg ClaimRegistry
+	if err := yaml.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("parsing registry file: %w", err)
+	}
+
+	return &reg, nil
+}
+
+// Save writes a ClaimRegistry to a YAML file
+func Save(path string, reg *ClaimRegistry) error {
+	if reg.APIVersion == "" {
+		reg.APIVersion = DefaultAPIVersion
+	}
+	if reg.Kind == "" {
+		reg.Kind = DefaultKind
+	}
+
+	data, err := yaml.Marshal(reg)
+	if err != nil {
+		return fmt.Errorf("marshalling registry: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing registry file: %w", err)
+	}
+
+	return nil
+}
+
+// AddEntry adds a claim entry to the registry.
+// If an entry with the same name already exists, it is replaced.
+func AddEntry(reg *ClaimRegistry, entry ClaimEntry) {
+	for i, e := range reg.Claims {
+		if e.Name == entry.Name {
+			reg.Claims[i] = entry
+			return
+		}
+	}
+	reg.Claims = append(reg.Claims, entry)
+}
+
+// RemoveEntry removes a claim entry by name.
+// Returns an error if the entry is not found.
+func RemoveEntry(reg *ClaimRegistry, name string) error {
+	for i, e := range reg.Claims {
+		if e.Name == name {
+			reg.Claims = append(reg.Claims[:i], reg.Claims[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("claim %q not found in registry", name)
+}
+
+// FindEntry returns a pointer to the claim entry with the given name, or nil.
+func FindEntry(reg *ClaimRegistry, name string) *ClaimEntry {
+	for i, e := range reg.Claims {
+		if e.Name == name {
+			return &reg.Claims[i]
+		}
+	}
+	return nil
+}
+
+// FilterEntries returns entries matching the given category and/or template.
+// Empty strings are treated as wildcards.
+func FilterEntries(reg *ClaimRegistry, category, template string) []ClaimEntry {
+	var result []ClaimEntry
+	for _, e := range reg.Claims {
+		if category != "" && e.Category != category {
+			continue
+		}
+		if template != "" && e.Template != template {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result
+}
+
+// NewRegistry creates an empty ClaimRegistry with default fields.
+func NewRegistry() *ClaimRegistry {
+	return &ClaimRegistry{
+		APIVersion: DefaultAPIVersion,
+		Kind:       DefaultKind,
+		Claims:     []ClaimEntry{},
+	}
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,142 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAndSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.yaml")
+
+	// Create a registry, save it, reload it
+	reg := NewRegistry()
+	AddEntry(reg, ClaimEntry{
+		Name:     "app-pvc",
+		Template: "volumeclaim",
+		Category: "infra",
+		Status:   "active",
+	})
+
+	if err := Save(path, reg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(loaded.Claims) != 1 {
+		t.Fatalf("expected 1 claim, got %d", len(loaded.Claims))
+	}
+	if loaded.Claims[0].Name != "app-pvc" {
+		t.Errorf("expected name app-pvc, got %s", loaded.Claims[0].Name)
+	}
+	if loaded.APIVersion != DefaultAPIVersion {
+		t.Errorf("expected apiVersion %s, got %s", DefaultAPIVersion, loaded.APIVersion)
+	}
+}
+
+func TestLoadNotFound(t *testing.T) {
+	_, err := Load("/nonexistent/registry.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestAddEntryReplace(t *testing.T) {
+	reg := NewRegistry()
+	AddEntry(reg, ClaimEntry{Name: "a", Status: "active"})
+	AddEntry(reg, ClaimEntry{Name: "a", Status: "deleted"})
+
+	if len(reg.Claims) != 1 {
+		t.Fatalf("expected 1 claim after replace, got %d", len(reg.Claims))
+	}
+	if reg.Claims[0].Status != "deleted" {
+		t.Errorf("expected status deleted, got %s", reg.Claims[0].Status)
+	}
+}
+
+func TestRemoveEntry(t *testing.T) {
+	reg := NewRegistry()
+	AddEntry(reg, ClaimEntry{Name: "a"})
+	AddEntry(reg, ClaimEntry{Name: "b"})
+
+	if err := RemoveEntry(reg, "a"); err != nil {
+		t.Fatalf("RemoveEntry: %v", err)
+	}
+	if len(reg.Claims) != 1 {
+		t.Fatalf("expected 1 claim, got %d", len(reg.Claims))
+	}
+	if reg.Claims[0].Name != "b" {
+		t.Errorf("expected b, got %s", reg.Claims[0].Name)
+	}
+}
+
+func TestRemoveEntryNotFound(t *testing.T) {
+	reg := NewRegistry()
+	if err := RemoveEntry(reg, "nonexistent"); err == nil {
+		t.Fatal("expected error for missing entry")
+	}
+}
+
+func TestFindEntry(t *testing.T) {
+	reg := NewRegistry()
+	AddEntry(reg, ClaimEntry{Name: "a", Template: "vol"})
+
+	found := FindEntry(reg, "a")
+	if found == nil {
+		t.Fatal("expected to find entry")
+	}
+	if found.Template != "vol" {
+		t.Errorf("expected template vol, got %s", found.Template)
+	}
+
+	if FindEntry(reg, "missing") != nil {
+		t.Error("expected nil for missing entry")
+	}
+}
+
+func TestFilterEntries(t *testing.T) {
+	reg := NewRegistry()
+	AddEntry(reg, ClaimEntry{Name: "a", Category: "infra", Template: "vol"})
+	AddEntry(reg, ClaimEntry{Name: "b", Category: "infra", Template: "net"})
+	AddEntry(reg, ClaimEntry{Name: "c", Category: "apps", Template: "vol"})
+
+	tests := []struct {
+		category string
+		template string
+		want     int
+	}{
+		{"infra", "", 2},
+		{"", "vol", 2},
+		{"infra", "vol", 1},
+		{"", "", 3},
+		{"missing", "", 0},
+	}
+
+	for _, tt := range tests {
+		got := FilterEntries(reg, tt.category, tt.template)
+		if len(got) != tt.want {
+			t.Errorf("FilterEntries(%q, %q): got %d, want %d", tt.category, tt.template, len(got), tt.want)
+		}
+	}
+}
+
+func TestSaveCreatesDirectories(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "registry.yaml")
+
+	// Should fail because parent dir doesn't exist
+	reg := NewRegistry()
+	err := Save(path, reg)
+	if err == nil {
+		// os.WriteFile doesn't create dirs, so this should fail
+		// unless the dir happens to exist
+		if _, statErr := os.Stat(filepath.Dir(path)); os.IsNotExist(statErr) {
+			t.Fatal("expected error writing to nonexistent directory")
+		}
+	}
+}

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -1,0 +1,22 @@
+package registry
+
+// ClaimRegistry represents the claims/registry.yaml file
+type ClaimRegistry struct {
+	APIVersion string       `yaml:"apiVersion"`
+	Kind       string       `yaml:"kind"`
+	Claims     []ClaimEntry `yaml:"claims"`
+}
+
+// ClaimEntry represents a single claim in the registry
+type ClaimEntry struct {
+	Name       string `yaml:"name"`
+	Template   string `yaml:"template"`
+	Category   string `yaml:"category"`
+	Namespace  string `yaml:"namespace"`
+	CreatedAt  string `yaml:"createdAt"`
+	CreatedBy  string `yaml:"createdBy"`
+	Source     string `yaml:"source"`
+	Repository string `yaml:"repository"`
+	Path       string `yaml:"path"`
+	Status     string `yaml:"status"`
+}

--- a/tests/api-profile.yaml
+++ b/tests/api-profile.yaml
@@ -1,10 +1,11 @@
 ---
 templates:
   - /home/sthings/projects/kcl/crossplane/claim-xplane-volumeclaim/templates/volumeclaim-simple.yaml
-  # - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-volumeclaim/templates/volumeclaim-simple.yaml
-  #- https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-harborproject/templates/harborproject-simple.yaml
-  #- https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-pipelineintegration/templates/pipelineintegration-simple.yaml
-  #- https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-storageplatform/templates/storageplatform-nfs.yaml
-  #- https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-storageplatform/templates/storageplatform-openebs.yaml
-  #- https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-vspherevm/templates/vspherevm-labul.yaml
-  #- https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-harvestervm/templates/harvestervm-simple.yaml
+  - /home/sthings/projects/kcl/crossplane/claim-xplane-harvestervm/templates/harvestervm-developer.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-volumeclaim/templates/volumeclaim-simple.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-harborproject/templates/harborproject-simple.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-pipelineintegration/templates/pipelineintegration-simple.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-storageplatform/templates/storageplatform-nfs.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-storageplatform/templates/storageplatform-openebs.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-vspherevm/templates/vspherevm-labul.yaml
+  - https://raw.githubusercontent.com/stuttgart-things/kcl/refs/heads/main/crossplane/claim-xplane-harvestervm/templates/harvestervm-simple.yaml


### PR DESCRIPTION
## Summary
- Add `delete` command with interactive and non-interactive modes, including git integration for committing and creating PRs on claim deletion
- Add `list` command to display claims from `registry.yaml`
- Add `internal/registry` package for CRUD operations on `claims/registry.yaml`
- Add `internal/kustomize` package for managing kustomization.yaml resources
- Render command now automatically updates `registry.yaml` with new claim entries
- GitOps `RemoveFiles` and `AddWithRemoved` methods added for staging file deletions

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/registry/` passes
- [x] `go test ./internal/kustomize/` passes
- [x] Manual test: `claims render` writes registry entry
- [x] Manual test: `claims list` shows registered claims
- [x] Manual test: `claims delete` removes claim files and registry entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)